### PR TITLE
Eclipse、IntelliJ IDEAのプロジェクト構成用のファイルをGitでは無視する

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,7 @@
 target
+.*
+!.gitignore
+*.iml
+*.ipr
+*.iws
+


### PR DESCRIPTION
Eclipseでは .project や .classpath といったファイル、.settings といった
ディレクトリをプロジェクト構成用に使用します。
(IntelliJ IDEAでは 201507_jjug.iml などのファイルを使用するようです。)

これらのファイルはEclipse(IntelliJ IDEA)を使用するために必要なものですが
必要があれば生成する(される)ので通常はバージョン管理の対象にはしません。

以上の理由から、こららのファイルをGitの管理対象にしないよう .gitignore
へ追記しました。
